### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nRFCloud/pizza


### PR DESCRIPTION
https://nordicsemi.atlassian.net/wiki/x/94HKq mandates PR reviews for production repositories. Adding a CODEOWNERS file to automatically request reviews from members of the Pizza team.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that affects GitHub review assignment but not runtime code or behavior.
> 
> **Overview**
> Adds a repository-wide `CODEOWNERS` rule (`* @nRFCloud/pizza`) so PRs automatically request review from the Pizza team.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a5149e463618ed1a88474d48d2828bbdd787fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->