### PR TITLE
fix: require Node.js 24.18.1 and npm 12 and use TypeScript v7

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "24.x"
+          node-version: ">=24.18.1 <25"
           cache: "npm"
 
       - name: Install dependencies

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+allow-remote=root


### PR DESCRIPTION
24.18.1 is a security release and NPM v12 also brings important security
improvements.

TypeScript 7 is now GA -> use it instead of the preview version

See <https://nodejs.org/en/blog/release/v24.18.1>
See <https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/>

- Bump `engines` to Node.js `>=24.18.1 <25` and npm `>=12.0.2 <13`.
- Add `allow-remote=root` to `.npmrc`. npm 12 refuses to fetch
  dependencies from tarball URLs by default; `root` permits the URLs this
  project declares in its own `package.json`. This is needed for example for
  dependencies hosted on JSR.
- Install the npm version from `engines.npm` in CI via a new
  `.github/actions/install-npm` composite action, so CI uses the version
  the project declares instead of whatever ships with the runner.
- Run TypeScript 6 and 7 side by side: `@typescript/native` provides
  TypeScript 7 as `tsc`, while `typescript` resolves to TypeScript 6 so
  typescript-eslint keeps working. This replaces
  `@typescript/native-preview`, so `npx tsgo` becomes `npx tsc` in the
  pre-commit hook, CI and the docs.
