### PR TITLE
docs: properly name the repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "@nrfcloud/fetch-with-debug",
   "version": "0.0.0-development",
   "description": "Simple wrapper around fetch that logs request and response.",
-  "homepage": "https://github.com/nrfcloud/fetch-with-debug#readme",
+  "homepage": "https://github.com/nRFCloud/fetch-with-debug#readme",
   "bugs": {
-    "url": "https://github.com/nrfcloud/fetch-with-debug/issues"
+    "url": "https://github.com/nRFCloud/fetch-with-debug/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nrfcloud/fetch-with-debug.git"
+    "url": "git+https://github.com/nRFCloud/fetch-with-debug.git"
   },
   "author": "Nordic Semiconductor ASA | nordicsemi.no",
   "scripts": {


### PR DESCRIPTION
Corrects the casing of the organization name in the `homepage`, `bugs.url` and
`repository.url` fields, from `nrfcloud` to `nRFCloud`.

This is needed for NPM trusted publishing to work, which matches the repository
owner and name case-sensitively.

Same change as
[nRFCloud/problem-detail@61646f1](https://github.com/nRFCloud/problem-detail/commit/61646f101883d4633489d2d8a47f0335610bb628).
